### PR TITLE
Fix '_get_search_id is not defined' on line 511 of rocker_timesheet.py

### DIFF
--- a/rocker_timesheet/models/rocker_timesheet.py
+++ b/rocker_timesheet/models/rocker_timesheet.py
@@ -507,7 +507,7 @@ class RockerTimesheet(models.Model):
         _selected_id = -1
         if vals.get('task_id') == False:
             _logger.debug('Task selected from searchpanel')
-            _selected_id = _get_search_id()
+            _selected_id = self._get_search_id()
             if _selected_id > 0:
                 _logger.debug('Selected id set, search task...')
                 search_task = self.env['project.task'].search([('id', '=', _selected_id)], limit=1)


### PR DESCRIPTION
The method _get_search_id was being called without the "self." prefix. Python couldn't find the method and threw a NameError exception.